### PR TITLE
Migrate to PHP 8.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 *.sublime-*
 /about
 build
+/.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 8.3
+  - 8.4
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 
 php:
-  - 7.0
-  - 7.1
-  - 7.2
+  - 8.3
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,11 @@
         {
             "name": "Amine Ben hammou",
             "email": "webneat@gmail.com"
+        },
+        {
+            "name": "Wojtek Brozyna",
+            "email": "wojciech.brozyna@gmail.com",
+            "role": "Maintainer (fork)"
         }
     ],
     "autoload": {
@@ -14,9 +19,17 @@
         }
     },
     "require": {
-        "php": "^7.0"
+        "php": "^8.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.3"
+        "phpunit/phpunit": "^10.5",
+        "squizlabs/php_codesniffer": "^3.10",
+        "rector/rector": "^2.2"
+    },
+    "scripts": {
+        "run-tests": "vendor/bin/phpunit --display-deprecations --display-phpunit-deprecations",
+        "code-sniff": "vendor/bin/phpcs -d memory_limit=512M -p src tests --standard=PSR12",
+        "code-fix": "vendor/bin/phpcbf -d memory_limit=512M -p src tests --standard=PSR12",
+        "rector": "vendor/bin/rector process"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     },
     "require": {
-        "php": "^8.3"
+        "php": "^8.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.5",
@@ -28,8 +28,8 @@
     },
     "scripts": {
         "run-tests": "vendor/bin/phpunit --display-deprecations --display-phpunit-deprecations",
-        "code-sniff": "vendor/bin/phpcs -d memory_limit=512M -p src tests --standard=PSR12",
-        "code-fix": "vendor/bin/phpcbf -d memory_limit=512M -p src tests --standard=PSR12",
+        "code-sniff": "vendor/bin/phpcs -d memory_limit=512M -p src --standard=PSR12",
+        "code-fix": "vendor/bin/phpcbf -d memory_limit=512M -p src --standard=PSR12",
         "rector": "vendor/bin/rector process"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e742d92d33cc04b9ebb3a832ff70b989",
+    "content-hash": "8e0e7ca6f75f5cf86748f27d0a038375",
     "packages": [],
     "packages-dev": [
         {
@@ -1875,7 +1875,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.3"
+        "php": "^8.4"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/composer.lock
+++ b/composer.lock
@@ -1,89 +1,44 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aa95f378ac9ed420c83df98c63d77470",
+    "content-hash": "e742d92d33cc04b9ebb3a832ff70b989",
     "packages": [],
     "packages-dev": [
         {
-            "name": "doctrine/instantiator",
-            "version": "1.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3,<8.0-DEV"
-            },
-            "require-dev": {
-                "athletic/athletic": "~0.1.8",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "time": "2015-06-14T21:17:01+00:00"
-        },
-        {
             "name": "myclabs/deep-copy",
-            "version": "1.6.1",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/8e6e04167378abf1ddb4d3522d8755c5fd90d102",
-                "reference": "8e6e04167378abf1ddb4d3522d8755c5fd90d102",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
             },
             "require-dev": {
-                "doctrine/collections": "1.*",
-                "phpunit/phpunit": "~4.1"
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
             },
             "type": "library",
             "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
                 "psr-4": {
                     "DeepCopy\\": "src/DeepCopy/"
                 }
@@ -93,7 +48,6 @@
                 "MIT"
             ],
             "description": "Create deep copies (clones) of your objects",
-            "homepage": "https://github.com/myclabs/DeepCopy",
             "keywords": [
                 "clone",
                 "copy",
@@ -101,32 +55,102 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-04-12T18:52:22+00:00"
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
-            "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "name": "nikic/php-parser",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
+            },
+            "time": "2025-10-21T19:32:17+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
-                "php": "^5.6 || ^7.0"
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -156,24 +180,34 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -203,254 +237,105 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-common",
-            "version": "1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
-            },
+            "name": "phpstan/phpstan",
+            "version": "2.1.31",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
-                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
+                "php": "^7.4|^8.0"
             },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
             },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
-                }
+                "files": [
+                    "bootstrap.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
-            "authors": [
-                {
-                    "name": "Jaap van Otterdijk",
-                    "email": "opensource@ijaap.nl"
-                }
-            ],
-            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
-            "homepage": "http://www.phpdoc.org",
+            "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
-                "FQSEN",
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
+                "dev",
                 "static analysis"
             ],
-            "time": "2015-12-27T11:43:31+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "3.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157"
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "reference": "4aada1f93c72c35e22fb1383b47fee43b8f1d157",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.5",
-                "phpdocumentor/reflection-common": "^1.0@dev",
-                "phpdocumentor/type-resolver": "^0.3.0",
-                "webmozart/assert": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-08-08T06:39:58+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "reference": "fb3933512008d8162b3cdf9e18dba9309b7c3773",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "time": "2017-06-03T08:32:36+00:00"
-        },
-        {
-            "name": "phpspec/prophecy",
-            "version": "v1.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
-                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "sebastian/comparator": "^1.1|^2.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
-            },
-            "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8 || ^5.6.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Konstantin Kudryashov",
-                    "email": "ever.zet@gmail.com",
-                    "homepage": "http://everzet.com"
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
                 },
                 {
-                    "name": "Marcello Duarte",
-                    "email": "marcello.duarte@gmail.com"
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
                 }
             ],
-            "description": "Highly opinionated mocking framework for PHP 5.3+",
-            "homepage": "https://github.com/phpspec/prophecy",
-            "keywords": [
-                "Double",
-                "Dummy",
-                "fake",
-                "mock",
-                "spy",
-                "stub"
-            ],
-            "time": "2017-03-02T20:05:34+00:00"
+            "time": "2025-10-10T14:14:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.2.2",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/8ed1902a57849e117b5651fc1a5c48110946c06b",
-                "reference": "8ed1902a57849e117b5651fc1a5c48110946c06b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
-                "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
-                "sebastian/version": "^2.0.1",
-                "theseer/tokenizer": "^1.1"
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "ext-xdebug": "^2.5",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.1"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.2.x-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -465,7 +350,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -476,29 +361,43 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-03T12:40:43+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.2",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
-                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -513,7 +412,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -523,26 +422,108 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03T07:40:28+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
         },
         {
-            "name": "phpunit/php-text-template",
-            "version": "1.2.1",
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
-                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -564,32 +545,43 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21T13:50:34+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -604,7 +596,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -613,69 +605,30 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
-        },
-        {
-            "name": "phpunit/php-token-stream",
-            "version": "2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "reference": "9a02332089ac48e704c70f6cefed30c224e3c0b0",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": "^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
                 }
             ],
-            "description": "Wrapper around PHP's tokenizer extension.",
-            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
-            "keywords": [
-                "tokenizer"
-            ],
-            "time": "2017-08-20T05:47:52+00:00"
+            "time": "2023-02-03T06:57:52+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.3.0",
+            "version": "10.5.58",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb"
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9501bab711403a1ab5b8378a8adb4ec3db3debdb",
-                "reference": "9501bab711403a1ab5b8378a8adb4ec3db3debdb",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e24fb46da450d8e6a5788670513c1af1424f16ca",
+                "reference": "e24fb46da450d8e6a5788670513c1af1424f16ca",
                 "shasum": ""
             },
             "require": {
@@ -684,35 +637,30 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
-                "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.2.2",
-                "phpunit/php-file-iterator": "^1.4.2",
-                "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^4.0.3",
-                "sebastian/comparator": "^2.0.2",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
-                "sebastian/exporter": "^3.1",
-                "sebastian/global-state": "^2.0",
-                "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
-                "sebastian/version": "^2.0.1"
-            },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
-            "require-dev": {
-                "ext-pdo": "*"
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.4",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
-                "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -720,10 +668,13 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.3.x-dev"
+                    "dev-main": "10.5-dev"
                 }
             },
             "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
                 "classmap": [
                     "src/"
                 ]
@@ -746,41 +697,119 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-08-04T05:20:39+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.58"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-28T12:04:46+00:00"
         },
         {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "4.0.4",
+            "name": "rector/rector",
+            "version": "2.2.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0"
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "022038537838bc8a4e526af86c2d6e38eaeff7ef"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/2f789b59ab89669015ad984afa350c4ec577ade0",
-                "reference": "2f789b59ab89669015ad984afa350c4ec577ade0",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/022038537838bc8a4e526af86c2d6e38eaeff7ef",
+                "reference": "022038537838bc8a4e526af86c2d6e38eaeff7ef",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.0"
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.1.26"
             },
             "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
             },
             "suggest": {
-                "ext-soap": "*"
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-29T15:46:12+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.0.x-dev"
+                    "dev-main": "2.0-dev"
                 }
             },
             "autoload": {
@@ -795,42 +824,105 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
             ],
-            "time": "2017-08-03T14:08:16+00:00"
+            "time": "2024-03-02T07:12:49+00:00"
         },
         {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "1.0.1",
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
-                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -850,34 +942,46 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "time": "2017-03-04T06:30:41+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.0.2",
+            "version": "5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a"
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
-                "reference": "ae068fede81d06e7bb9bb46a367210a3d3e1fe6a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e8e53097718d2b53cfb2aa859b06a41abf58c62e",
+                "reference": "e8e53097718d2b53cfb2aa859b06a41abf58c62e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0",
-                "sebastian/exporter": "^3.0"
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -890,6 +994,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -901,45 +1009,65 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
             "keywords": [
                 "comparator",
                 "compare",
                 "equality"
             ],
-            "time": "2017-08-03T07:14:59+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-07T05:25:07+00:00"
         },
         {
-            "name": "sebastian/diff",
-            "version": "2.0.1",
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "3.2-dev"
                 }
             },
             "autoload": {
@@ -953,45 +1081,120 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
                 {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "6.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1010,40 +1213,51 @@
                 }
             ],
             "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "homepage": "https://github.com/sebastianbergmann/environment",
             "keywords": [
                 "Xdebug",
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "3.1.0",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
-                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/recursion-context": "^3.0"
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -1057,6 +1271,10 @@
             ],
             "authors": [
                 {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
                 },
@@ -1065,53 +1283,72 @@
                     "email": "github@wallbash.com"
                 },
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Adam Harvey",
                     "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
-            "time": "2017-04-03T13:19:02+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "2.0.0",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
-                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
-            },
-            "suggest": {
-                "ext-uopz": "*"
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -1130,38 +1367,107 @@
                 }
             ],
             "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
             "keywords": [
                 "global state"
             ],
-            "time": "2017-04-27T15:39:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
         },
         {
-            "name": "sebastian/object-enumerator",
-            "version": "3.0.3",
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
-                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/object-reflector": "^1.1.1",
-                "sebastian/recursion-context": "^3.0"
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1181,32 +1487,42 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "time": "2017-08-03T12:35:26+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "1.1.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
-                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1226,32 +1542,42 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "time": "2017-03-29T09:07:27+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "3.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
-                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -1265,12 +1591,12 @@
             ],
             "authors": [
                 {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
                 },
                 {
                     "name": "Adam Harvey",
@@ -1278,30 +1604,56 @@
                 }
             ],
             "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2017-03-03T06:23:57+00:00"
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
         },
         {
-            "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "name": "sebastian/type",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1316,34 +1668,45 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
                 }
             ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "2.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
-                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": ">=8.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -1364,27 +1727,116 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2016-10-03T07:35:21+00:00"
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.1.0",
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
-                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "autoload": {
@@ -1404,64 +1856,27 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2017-04-07T12:08:54+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
             },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.3 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
+            "funding": [
                 {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
+                    "url": "https://github.com/theseer",
+                    "type": "github"
                 }
             ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "time": "2016-11-23T20:04:58+00:00"
+            "time": "2024-03-03T12:36:25+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": []
+    "platform": {
+        "php": "^8.3"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  php83:
+  php84:
     container_name: tarsana-filesystem-dev
     build: ./docker
     working_dir: /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  php83:
+    container_name: tarsana-filesystem-dev
+    build: ./docker
+    working_dir: /app
+    volumes:
+      - ./:/app
+    # Run a script or just show the PHP version
+    command: bash -c "composer install"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,37 @@
+FROM php:8.3-cli
+
+# Install system dependencies needed for Composer, Git, and building extensions
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    unzip \
+    zip \
+    gzip \
+    libzip-dev \
+    libonig-dev \
+    libxml2-dev \
+    && docker-php-ext-install zip mbstring xml \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+# Enable Xdebug coverage mode
+ENV XDEBUG_MODE=coverage
+
+# Install the latest Composer (v2)
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && rm composer-setup.php
+
+# Make /app a "safe" Git directory
+RUN git config --global --add safe.directory /app
+
+# Verify installation
+RUN composer --version && git --version
+
+# Add non root usert
+RUN useradd -ms /bin/bash appuser
+USER appuser
+
+WORKDIR /app
+COPY . /app

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.3-cli
+FROM php:8.4-cli
 
 # Install system dependencies needed for Composer, Git, and building extensions
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN git config --global --add safe.directory /app
 # Verify installation
 RUN composer --version && git --version
 
-# Add non root usert
+# Add non root user
 RUN useradd -ms /bin/bash appuser
 USER appuser
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,26 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="tests/bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false"
->
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <testsuites>
-        <testsuite name="Tarsana Filesystem Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache" failOnRisky="true" failOnWarning="true">
+  <testsuites>
+    <testsuite name="Tarsana File System Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    // uncomment to reach your current PHP version
+    ->withPhpSets()
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/rector.php
+++ b/rector.php
@@ -11,6 +11,6 @@ return RectorConfig::configure()
     ])
     // uncomment to reach your current PHP version
     ->withPhpSets()
-    ->withTypeCoverageLevel(0)
-    ->withDeadCodeLevel(0)
-    ->withCodeQualityLevel(0);
+    ->withTypeCoverageLevel(10)
+    ->withDeadCodeLevel(10)
+    ->withCodeQualityLevel(10);

--- a/src/AbstractFile.php
+++ b/src/AbstractFile.php
@@ -1,5 +1,6 @@
-<?php namespace Tarsana\Filesystem;
+<?php
 
+namespace Tarsana\Filesystem;
 
 use Tarsana\Filesystem\Filesystem;
 use Tarsana\Filesystem\Adapters\Local;
@@ -7,16 +8,8 @@ use Tarsana\Filesystem\Interfaces\Adapter;
 use Tarsana\Filesystem\Exceptions\FilesystemException;
 use Tarsana\Filesystem\Interfaces\AbstractFile as AbstractFileInterface;
 
-
-abstract class AbstractFile implements AbstractFileInterface {
-
-    /**
-     * Absolute path to the file.
-     *
-     * @var string
-     */
-    protected $path;
-
+abstract class AbstractFile implements AbstractFileInterface
+{
     /**
      * The filesystem instance having the same path
      * if this is directory and poiting to the
@@ -46,10 +39,12 @@ abstract class AbstractFile implements AbstractFileInterface {
      *
      * @param string $path
      */
-    public function __construct($path, Adapter $adapter = null)
+    public function __construct(/**
+     * Absolute path to the file.
+     */
+    protected $path, Adapter $adapter = null)
     {
-        $this->adapter = (null !== $adapter) ? $adapter : Local::instance();
-        $this->path = $path;
+        $this->adapter = $adapter ?? Local::instance();
         $this->pathListeners = [];
         $this->fs = null; // will create it when needed
 
@@ -155,8 +150,7 @@ abstract class AbstractFile implements AbstractFileInterface {
     public function addPathListener($cb)
     {
         $this->pathListeners[] = $cb;
-        end($this->pathListeners);
-        return key($this->pathListeners);
+        return array_key_last($this->pathListeners);
     }
 
     /**
@@ -202,8 +196,9 @@ abstract class AbstractFile implements AbstractFileInterface {
      */
     public function fs()
     {
-        if (null === $this->fs)
+        if (null === $this->fs) {
             $this->fs = new Filesystem($this->getFilesystemPath(), $this->adapter);
+        }
         return $this->fs;
     }
 
@@ -232,14 +227,14 @@ abstract class AbstractFile implements AbstractFileInterface {
      *
      * @return boolean
      */
-    public abstract function exists();
+    abstract public function exists();
 
     /**
      * Creates the file if it doesn't exist.
      *
      * @return Tarsana\Filesystem\AbstractFile
      */
-    public abstract function create();
+    abstract public function create();
 
     /**
      * Throws a FilesystemException meaning that
@@ -249,14 +244,14 @@ abstract class AbstractFile implements AbstractFileInterface {
      *
      * @throws Tarsana\Filesystem\Exceptions\FilesystemException
      */
-    protected abstract function throwUnableToCreate();
+    abstract protected function throwUnableToCreate();
 
     /**
      * Gets the path of the directory or the parent directory if this is a file.
      *
      * @return string
      */
-    protected abstract function getFilesystemPath();
+    abstract protected function getFilesystemPath();
 
     /**
      * Copies the file to the provided destination and returns the copy.
@@ -266,6 +261,5 @@ abstract class AbstractFile implements AbstractFileInterface {
      *
      * @throws Tarsana\Filesystem\Exceptions\FilesystemException if unable to create the destination file.
      */
-    public abstract function copyAs($dest);
-
+    abstract public function copyAs($dest);
 }

--- a/src/AbstractFile.php
+++ b/src/AbstractFile.php
@@ -40,10 +40,11 @@ abstract class AbstractFile implements AbstractFileInterface
      * @param string $path
      */
     public function __construct(/**
-     * Absolute path to the file.
-     */
-    protected $path, Adapter $adapter = null)
-    {
+         * Absolute path to the file.
+         */
+        protected $path,
+        ?Adapter $adapter = null
+    ) {
         $this->adapter = $adapter ?? Local::instance();
         $this->pathListeners = [];
         $this->fs = null; // will create it when needed
@@ -113,7 +114,7 @@ abstract class AbstractFile implements AbstractFileInterface
             throw new FilesystemException("Cannot rename the file '{$this->path}' to '{$value}' because a file already exists");
         }
 
-        (new static($value, $this->adapter))->remove();
+        new static($value, $this->adapter)->remove();
 
         if (! $this->adapter->rename($this->path, $value)) {
             throw new FilesystemException("Cannot rename the file '{$this->path}' to '{$value}'");

--- a/src/Adapters/Local.php
+++ b/src/Adapters/Local.php
@@ -1,10 +1,11 @@
-<?php namespace Tarsana\Filesystem\Adapters;
+<?php
+
+namespace Tarsana\Filesystem\Adapters;
 
 use Tarsana\Filesystem\Interfaces\Adapter;
 
-
-class Local implements Adapter {
-
+class Local implements Adapter
+{
     /**
      * The singleton instance.
      *
@@ -20,7 +21,7 @@ class Local implements Adapter {
     public static function instance()
     {
         if (null === self::$instance) {
-            self::$instance = new Local;
+            self::$instance = new Local();
         }
         return self::$instance;
     }
@@ -28,7 +29,9 @@ class Local implements Adapter {
     /**
      * Priate Constructor.
      */
-    private function __construct() {}
+    private function __construct()
+    {
+    }
 
     /**
      * Tells if the given path is absolute.
@@ -257,8 +260,9 @@ class Local implements Adapter {
     public function createFile($path)
     {
         $created = fopen($path, "w");
-        if (false === $created)
+        if (false === $created) {
             return false;
+        }
 
         fclose($created);
         return true;
@@ -285,5 +289,4 @@ class Local implements Adapter {
     {
         return basename($path);
     }
-
 }

--- a/src/Adapters/Local.php
+++ b/src/Adapters/Local.php
@@ -11,7 +11,7 @@ class Local implements Adapter
      *
      * @var self
      */
-    protected static $instance = null;
+    protected static $instance;
 
     /**
      * Gets the singleton instance.
@@ -257,7 +257,7 @@ class Local implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function createFile($path)
+    public function createFile($path): bool
     {
         $created = fopen($path, "w");
         if (false === $created) {

--- a/src/Adapters/Memory.php
+++ b/src/Adapters/Memory.php
@@ -102,7 +102,7 @@ class Memory implements Adapter
      * @param  string $pattern
      * @return array
      */
-    public function glob($pattern)
+    public function glob($pattern): array
     {
         $matched = [];
         $pattern = $this->realpath($pattern);
@@ -184,7 +184,7 @@ class Memory implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function filePutContents($path, $content, $flags = 0)
+    public function filePutContents($path, $content, $flags = 0): bool
     {
         if (! $this->isFile($path) && !$this->createFile($path)) {
             return false;
@@ -244,7 +244,7 @@ class Memory implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function unlink($path)
+    public function unlink($path): bool
     {
         $this->at($path, null);
         return true;
@@ -256,7 +256,7 @@ class Memory implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function rmdir($path)
+    public function rmdir($path): bool
     {
         $path = $this->realpath($path) . '/';
         $length = strlen($path);
@@ -275,7 +275,7 @@ class Memory implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function rename($oldPath, $newPath)
+    public function rename($oldPath, $newPath): bool
     {
         $old = $this->at($oldPath);
         $new = $this->at($newPath);
@@ -326,7 +326,7 @@ class Memory implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function chmod($path, $value)
+    public function chmod($path, $value): bool
     {
         $node = $this->at($path);
         if (null === $node || !is_numeric($value)) {
@@ -353,7 +353,7 @@ class Memory implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function mkdir($path, $mode = 0777, $recursive = false)
+    public function mkdir($path, $mode = 0777, $recursive = false): bool
     {
         if (null !== $this->at($path)) {
             trigger_error("mkdir(): File exists");
@@ -400,7 +400,7 @@ class Memory implements Adapter
      * @param  string  $path
      * @return boolean
      */
-    public function createFile($path)
+    public function createFile($path): bool
     {
         $node = $this->at($path);
         if ($node !== null && $node->type == 'dir') {

--- a/src/Adapters/Memory.php
+++ b/src/Adapters/Memory.php
@@ -1,10 +1,11 @@
-<?php namespace Tarsana\Filesystem\Adapters;
+<?php
+
+namespace Tarsana\Filesystem\Adapters;
 
 use Tarsana\Filesystem\Interfaces\Adapter;
 
-
-class Memory implements Adapter {
-
+class Memory implements Adapter
+{
     /**
      * Associative array of files and directories.
      * [
@@ -43,10 +44,11 @@ class Memory implements Adapter {
         $path = $this->realpath($path);
 
         if (false === $value) {
-            if (isset($this->files[$path]))
+            if (isset($this->files[$path])) {
                 return $this->files[$path];
-            else
+            } else {
                 return null;
+            }
         }
 
         if (null === $value) {
@@ -66,7 +68,7 @@ class Memory implements Adapter {
      */
     public function isAbsolute($path)
     {
-        return substr($path, 0, 1) == '/';
+        return str_starts_with($path, '/');
     }
 
     /**
@@ -87,7 +89,7 @@ class Memory implements Adapter {
         foreach ($parts as $part) {
             if ($part == '..') {
                 array_pop($path);
-            } else if ($part != '.') {
+            } elseif ($part != '.') {
                 array_push($path, $part);
             }
         }
@@ -104,10 +106,11 @@ class Memory implements Adapter {
     {
         $matched = [];
         $pattern = $this->realpath($pattern);
-        $pattern = '@^' . str_replace(['\*', '\?'], ['[^\\\/]*', '.'], preg_quote($pattern)) .'$@';
+        $pattern = '@^' . str_replace(['\*', '\?'], ['[^\\\/]*', '.'], preg_quote($pattern)) . '$@';
         foreach (array_keys($this->files) as $path) {
-            if (preg_match($pattern, $path))
+            if (preg_match($pattern, (string) $path)) {
                 $matched[] = $path;
+            }
         }
         return $matched;
     }
@@ -155,9 +158,10 @@ class Memory implements Adapter {
      */
     public function md5File($path)
     {
-        if (! $this->isFile($path))
+        if (! $this->isFile($path)) {
             return false;
-        return md5($this->at($path)->content);
+        }
+        return md5((string) $this->at($path)->content);
     }
 
     /**
@@ -168,8 +172,9 @@ class Memory implements Adapter {
      */
     public function fileGetContents($path)
     {
-        if (! $this->isFile($path))
+        if (! $this->isFile($path)) {
             return false;
+        }
         return $this->at($path)->content;
     }
 
@@ -181,12 +186,14 @@ class Memory implements Adapter {
      */
     public function filePutContents($path, $content, $flags = 0)
     {
-        if (! $this->isFile($path) && !$this->createFile($path))
+        if (! $this->isFile($path) && !$this->createFile($path)) {
             return false;
-        if (($flags & FILE_APPEND) == FILE_APPEND)
+        }
+        if (($flags & FILE_APPEND) == FILE_APPEND) {
             $this->at($path)->content .= $content;
-        else
+        } else {
             $this->at($path)->content = $content;
+        }
         return true;
     }
 
@@ -254,7 +261,7 @@ class Memory implements Adapter {
         $path = $this->realpath($path) . '/';
         $length = strlen($path);
         foreach (array_keys($this->files) as $filename) {
-            if (substr($filename, 0, $length) === $path) {
+            if (substr((string) $filename, 0, $length) === $path) {
                 return false;
             }
         }
@@ -273,8 +280,9 @@ class Memory implements Adapter {
         $old = $this->at($oldPath);
         $new = $this->at($newPath);
 
-        if (null === $old || (null !== $new && 'dir' === $new->type))
+        if (null === $old || (null !== $new && 'dir' === $new->type)) {
             return false;
+        }
 
         if ('file' === $old->type) {
             $this->at($newPath, $old);
@@ -286,8 +294,8 @@ class Memory implements Adapter {
             $newPath = $this->realpath($newPath) . '/';
             $length = strlen($oldPath);
             foreach (array_keys($this->files) as $childPath) {
-                if (substr($childPath, 0, $length) === $oldPath) {
-                    $newChildPath = $newPath . substr($childPath, $length);
+                if (substr((string) $childPath, 0, $length) === $oldPath) {
+                    $newChildPath = $newPath . substr((string) $childPath, $length);
                     $this->at($newChildPath, $this->at($childPath));
                     $this->at($childPath, null);
                 }
@@ -361,8 +369,8 @@ class Memory implements Adapter {
             $node = $this->at($item);
             if ($node === null) {
                 $missing[] = $item;
-            } else if ($node->type == 'file') {
-                $filesCount ++;
+            } elseif ($node->type == 'file') {
+                $filesCount++;
             }
         }
 
@@ -384,7 +392,7 @@ class Memory implements Adapter {
         }
 
         return true;
-   }
+    }
 
     /**
      * Creates a new empty file, overrite.
@@ -434,5 +442,4 @@ class Memory implements Adapter {
     {
         return basename($path);
     }
-
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -97,7 +97,7 @@ class Collection implements CollectionInterface
      */
     public function files()
     {
-        $filesList = array_filter($this->items, fn($item) => $item['instance'] instanceof FileInterface);
+        $filesList = array_filter($this->items, fn($item): bool => $item['instance'] instanceof FileInterface);
 
         $filesList = array_map(fn($item) => $item['instance'], $filesList);
 
@@ -111,7 +111,7 @@ class Collection implements CollectionInterface
      */
     public function dirs()
     {
-        $filesList = array_filter($this->items, fn($item) => $item['instance'] instanceof DirectoryInterface);
+        $filesList = array_filter($this->items, fn($item): bool => $item['instance'] instanceof DirectoryInterface);
 
         $filesList = array_map(fn($item) => $item['instance'], $filesList);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -1,11 +1,13 @@
-<?php namespace Tarsana\Filesystem;
+<?php
+
+namespace Tarsana\Filesystem;
 
 use Tarsana\Filesystem\Interfaces\Collection as CollectionInterface;
 use Tarsana\Filesystem\Interfaces\Directory as DirectoryInterface;
 use Tarsana\Filesystem\Interfaces\File as FileInterface;
 
-class Collection implements CollectionInterface {
-
+class Collection implements CollectionInterface
+{
     /**
      * Array containing the items, it's indexed by the
      * path of items and holds other informations
@@ -41,10 +43,10 @@ class Collection implements CollectionInterface {
             foreach ($item as $element) {
                 $this->add($element);
             }
-        } else if (! $this->contains($item->path())) {
+        } elseif (! $this->contains($item->path())) {
             $this->items[$item->path()] = [
                 'instance' => $item,
-                'listener_index' => $item->addPathListener([$this, 'updatePath'])
+                'listener_index' => $item->addPathListener($this->updatePath(...))
             ];
         }
         return $this;
@@ -95,13 +97,9 @@ class Collection implements CollectionInterface {
      */
     public function files()
     {
-        $filesList = array_filter($this->items, function($item) {
-            return ($item['instance'] instanceof FileInterface);
-        });
+        $filesList = array_filter($this->items, fn($item) => $item['instance'] instanceof FileInterface);
 
-        $filesList = array_map(function($item) {
-            return $item['instance'];
-        }, $filesList);
+        $filesList = array_map(fn($item) => $item['instance'], $filesList);
 
         return new Collection($filesList);
     }
@@ -113,13 +111,9 @@ class Collection implements CollectionInterface {
      */
     public function dirs()
     {
-        $filesList = array_filter($this->items, function($item) {
-            return ($item['instance'] instanceof DirectoryInterface);
-        });
+        $filesList = array_filter($this->items, fn($item) => $item['instance'] instanceof DirectoryInterface);
 
-        $filesList = array_map(function($item) {
-            return $item['instance'];
-        }, $filesList);
+        $filesList = array_map(fn($item) => $item['instance'], $filesList);
 
         return new Collection($filesList);
     }
@@ -131,9 +125,7 @@ class Collection implements CollectionInterface {
      */
     public function asArray()
     {
-        return array_map(function($item) {
-            return $item['instance'];
-        }, $this->items);
+        return array_map(fn($item) => $item['instance'], $this->items);
     }
 
     /**
@@ -181,7 +173,7 @@ class Collection implements CollectionInterface {
      */
     public function names()
     {
-        return array_map('basename', array_keys($this->items));
+        return array_map(basename(...), array_keys($this->items));
     }
 
     /**
@@ -213,5 +205,4 @@ class Collection implements CollectionInterface {
         }
         return $this;
     }
-
 }

--- a/src/Directory.php
+++ b/src/Directory.php
@@ -1,12 +1,13 @@
-<?php namespace Tarsana\Filesystem;
+<?php
+
+namespace Tarsana\Filesystem;
 
 use Tarsana\Filesystem\Interfaces\Directory as DirectoryInterface;
 use Tarsana\Filesystem\Exceptions\FilesystemException;
 use Tarsana\Filesystem\AbstractFile;
 
-
-class Directory extends AbstractFile implements DirectoryInterface {
-
+class Directory extends AbstractFile implements DirectoryInterface
+{
     /**
      * Tells if the directory exists.
      *
@@ -36,7 +37,7 @@ class Directory extends AbstractFile implements DirectoryInterface {
      *
      * @throws Tarsana\Filesystem\Exceptions\FilesystemException
      */
-    protected function throwUnableToCreate()
+    protected function throwUnableToCreate(): never
     {
         throw new FilesystemException("Unable to create the directory '{$this->path}'. A file with the same path already exists.");
     }
@@ -71,5 +72,4 @@ class Directory extends AbstractFile implements DirectoryInterface {
 
         return $copy;
     }
-
 }

--- a/src/Exceptions/FilesystemException.php
+++ b/src/Exceptions/FilesystemException.php
@@ -1,4 +1,7 @@
-<?php namespace Tarsana\Filesystem\Exceptions;
+<?php
 
+namespace Tarsana\Filesystem\Exceptions;
 
-class FilesystemException extends \Exception {}
+class FilesystemException extends \Exception
+{
+}

--- a/src/Exceptions/ResourceException.php
+++ b/src/Exceptions/ResourceException.php
@@ -1,3 +1,7 @@
-<?php namespace Tarsana\Filesystem\Exceptions;
+<?php
 
-class ResourceException extends \Exception {}
+namespace Tarsana\Filesystem\Exceptions;
+
+class ResourceException extends \Exception
+{
+}

--- a/src/File.php
+++ b/src/File.php
@@ -1,12 +1,13 @@
-<?php namespace Tarsana\Filesystem;
+<?php
+
+namespace Tarsana\Filesystem;
 
 use Tarsana\Filesystem\Interfaces\File as FileInterface;
 use Tarsana\Filesystem\Exceptions\FilesystemException;
 use Tarsana\Filesystem\AbstractFile;
 
-
-class File extends AbstractFile implements FileInterface {
-
+class File extends AbstractFile implements FileInterface
+{
     /**
      * Tells if the file exists.
      *
@@ -42,7 +43,7 @@ class File extends AbstractFile implements FileInterface {
      *
      * @throws Tarsana\Filesystem\Exceptions\FilesystemException
      */
-    protected function throwUnableToCreate()
+    protected function throwUnableToCreate(): never
     {
         throw new FilesystemException("Unable to create the file '{$this->path}'. A directory with the same path already exists.");
     }
@@ -122,7 +123,7 @@ class File extends AbstractFile implements FileInterface {
      */
     public function extension($extension = false)
     {
-        if($extension === false) {
+        if ($extension === false) {
             return $this->adapter->extension($this->path);
         }
 

--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -36,7 +36,7 @@ class Filesystem implements FilesystemInterface
      * @param Tarsana\Filesystem\Interfaces\Adapter $adapter
      * @throws FilesystemException If root path is not a directory.
      **/
-    public function __construct($rootPath, Adapter $adapter = null)
+    public function __construct($rootPath, ?Adapter $adapter = null)
     {
         if (null === $adapter) {
             $adapter = Local::instance();

--- a/src/Interfaces/AbstractFile.php
+++ b/src/Interfaces/AbstractFile.php
@@ -1,7 +1,9 @@
-<?php namespace Tarsana\Filesystem\Interfaces;
+<?php
 
-interface AbstractFile {
+namespace Tarsana\Filesystem\Interfaces;
 
+interface AbstractFile
+{
     /**
      * Tells if the file exists or can be created. In case of a directory
      * for example, this will return false if a file exists with the
@@ -98,5 +100,4 @@ interface AbstractFile {
      * @throws Tarsana\Filesystem\Exceptions\FilesystemException if unable to create the destination file.
      */
     public function copyAs($dest);
-
 }

--- a/src/Interfaces/Adapter.php
+++ b/src/Interfaces/Adapter.php
@@ -1,10 +1,12 @@
-<?php namespace Tarsana\Filesystem\Interfaces;
+<?php
+
+namespace Tarsana\Filesystem\Interfaces;
 
 /**
  * Filesystem adapter: defines the low level functions for a specific filesystem
  */
-interface Adapter {
-
+interface Adapter
+{
     /**
      * Tells if the given path is absolute.
      *
@@ -181,5 +183,4 @@ interface Adapter {
      * @return boolean
      */
     public function basename($path);
-
 }

--- a/src/Interfaces/Collection.php
+++ b/src/Interfaces/Collection.php
@@ -1,7 +1,9 @@
-<?php namespace Tarsana\Filesystem\Interfaces;
+<?php
 
-interface Collection {
+namespace Tarsana\Filesystem\Interfaces;
 
+interface Collection
+{
     /**
      * Adds new items to the collection. If an
      * item already exists It will be ignored.
@@ -101,5 +103,4 @@ interface Collection {
      * @return Tarsana\Filesystem\Interfaces\Collection
      */
     public function remove($path);
-
 }

--- a/src/Interfaces/Directory.php
+++ b/src/Interfaces/Directory.php
@@ -1,3 +1,7 @@
-<?php namespace Tarsana\Filesystem\Interfaces;
+<?php
 
-interface Directory extends AbstractFile {}
+namespace Tarsana\Filesystem\Interfaces;
+
+interface Directory extends AbstractFile
+{
+}

--- a/src/Interfaces/File.php
+++ b/src/Interfaces/File.php
@@ -1,8 +1,9 @@
-<?php namespace Tarsana\Filesystem\Interfaces;
+<?php
 
+namespace Tarsana\Filesystem\Interfaces;
 
-interface File extends AbstractFile {
-
+interface File extends AbstractFile
+{
     /**
      * Gets a hash of the file/directory content.
      *
@@ -50,5 +51,4 @@ interface File extends AbstractFile {
      * @return boolean
      */
     public function isExecutable();
-
 }

--- a/src/Interfaces/Filesystem.php
+++ b/src/Interfaces/Filesystem.php
@@ -1,10 +1,12 @@
-<?php namespace Tarsana\Filesystem\Interfaces;
+<?php
+
+namespace Tarsana\Filesystem\Interfaces;
 
 /**
  * Finds and handles files and directories within a root directory.
  */
-interface Filesystem {
-
+interface Filesystem
+{
     /**
      * Gets the root path.
      *
@@ -197,5 +199,4 @@ interface Filesystem {
      * @return Tarsana\Filesystem\Interfaces
      */
     public function removeAll($paths);
-
 }

--- a/src/Interfaces/Resource/Buffer.php
+++ b/src/Interfaces/Resource/Buffer.php
@@ -1,6 +1,10 @@
-<?php namespace Tarsana\Filesystem\Interfaces\Resource;
+<?php
+
+namespace Tarsana\Filesystem\Interfaces\Resource;
 
 /**
  * Reads/Writes content from/into a stream of data.
  */
-interface Buffer extends Reader, Writer {}
+interface Buffer extends Reader, Writer
+{
+}

--- a/src/Interfaces/Resource/Reader.php
+++ b/src/Interfaces/Resource/Reader.php
@@ -1,10 +1,12 @@
-<?php namespace Tarsana\Filesystem\Interfaces\Resource;
+<?php
+
+namespace Tarsana\Filesystem\Interfaces\Resource;
 
 /**
  * Reads content from a text resource.
  */
-interface Reader {
-
+interface Reader
+{
     /**
      * Reads a number of chars/bytes from the stream.
      * If `$count == 0`; reads all the available content.
@@ -38,5 +40,4 @@ interface Reader {
      * @return string
      */
     public function readUntil($end);
-
 }

--- a/src/Interfaces/Resource/Writer.php
+++ b/src/Interfaces/Resource/Writer.php
@@ -1,10 +1,12 @@
-<?php namespace Tarsana\Filesystem\Interfaces\Resource;
+<?php
+
+namespace Tarsana\Filesystem\Interfaces\Resource;
 
 /**
  * Writes content into a text resource.
  */
-interface Writer {
-
+interface Writer
+{
     /**
      * Writes content.
      *
@@ -20,5 +22,4 @@ interface Writer {
      * @return self
      */
     public function writeLine($text);
-
 }

--- a/src/Resource/Buffer.php
+++ b/src/Resource/Buffer.php
@@ -134,7 +134,7 @@ class Buffer extends ResourceHanlder implements BufferInterface
      *
      * @return string
      */
-    protected function defaultMode()
+    protected function defaultMode(): string
     {
         return 'a+b';
     }
@@ -144,7 +144,7 @@ class Buffer extends ResourceHanlder implements BufferInterface
      *
      * @return string|resource
      */
-    protected function defaultResource()
+    protected function defaultResource(): string
     {
         return 'php://memory';
     }

--- a/src/Resource/Buffer.php
+++ b/src/Resource/Buffer.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Filesystem\Resource;
+<?php
+
+namespace Tarsana\Filesystem\Resource;
 
 use Tarsana\Filesystem\Interfaces\Resource\Buffer as BufferInterface;
 use Tarsana\Filesystem\Exceptions\ResourceException;
@@ -6,8 +8,8 @@ use Tarsana\Filesystem\Exceptions\ResourceException;
 /**
  * Reads and writes content from/to a resource.
  */
-class Buffer extends ResourceHanlder implements BufferInterface {
-
+class Buffer extends ResourceHanlder implements BufferInterface
+{
     /**
      * The current writting position in the file.
      *
@@ -109,8 +111,9 @@ class Buffer extends ResourceHanlder implements BufferInterface {
     public function write($content)
     {
         fseek($this->resource, $this->writePosition);
-        if(false === fwrite($this->resource, $content))
+        if (false === fwrite($this->resource, $content)) {
             throw new ResourceException("Unable to write content to resource");
+        }
         $this->writePosition = ftell($this->resource);
         return $this;
     }
@@ -156,5 +159,4 @@ class Buffer extends ResourceHanlder implements BufferInterface {
     {
         return $this->isReadable($resource) && $this->isWritable($resource);
     }
-
 }

--- a/src/Resource/Reader.php
+++ b/src/Resource/Reader.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Filesystem\Resource;
+<?php
+
+namespace Tarsana\Filesystem\Resource;
 
 use Tarsana\Filesystem\Exceptions\ResourceException;
 use Tarsana\Filesystem\Interfaces\Resource\Reader as ReaderInterface;
@@ -6,8 +8,8 @@ use Tarsana\Filesystem\Interfaces\Resource\Reader as ReaderInterface;
 /**
  * Reads content from a resource.
  */
-class Reader extends ResourceHanlder implements ReaderInterface {
-
+class Reader extends ResourceHanlder implements ReaderInterface
+{
     /**
      * Reads a number of chars/bytes from the stream.
      * If `$count == 0`; reads all the available content.
@@ -96,5 +98,4 @@ class Reader extends ResourceHanlder implements ReaderInterface {
     {
         return $this->isReadable($resource);
     }
-
 }

--- a/src/Resource/Reader.php
+++ b/src/Resource/Reader.php
@@ -73,7 +73,7 @@ class Reader extends ResourceHanlder implements ReaderInterface
      *
      * @return string
      */
-    protected function defaultMode()
+    protected function defaultMode(): string
     {
         return 'rb';
     }
@@ -83,7 +83,7 @@ class Reader extends ResourceHanlder implements ReaderInterface
      *
      * @return string|resource
      */
-    protected function defaultResource()
+    protected function defaultResource(): string
     {
         return 'php://stdin';
     }

--- a/src/Resource/ResourceHanlder.php
+++ b/src/Resource/ResourceHanlder.php
@@ -1,12 +1,14 @@
-<?php namespace Tarsana\Filesystem\Resource;
+<?php
+
+namespace Tarsana\Filesystem\Resource;
 
 use Tarsana\Filesystem\Exceptions\ResourceException;
 
 /**
  * Abstract class offering basic methods to handle a resource.
  */
-abstract class ResourceHanlder {
-
+abstract class ResourceHanlder
+{
     /**
      * The resource to handle.
      *
@@ -56,8 +58,9 @@ abstract class ResourceHanlder {
             $data = stream_get_meta_data($this->resource);
             return $data['blocked'];
         }
-        if (stream_set_blocking($this->resource, $mode))
+        if (stream_set_blocking($this->resource, $mode)) {
             return $this;
+        }
         throw new ResourceException("Unable to set the blocking mode of resource");
     }
 
@@ -68,8 +71,9 @@ abstract class ResourceHanlder {
      */
     public function close()
     {
-        if (is_resource($this->resource))
+        if (is_resource($this->resource)) {
             fclose($this->resource);
+        }
         return $this;
     }
 
@@ -130,5 +134,4 @@ abstract class ResourceHanlder {
      * @return boolean
      */
     abstract protected function isValid($resource);
-
 }

--- a/src/Resource/Writer.php
+++ b/src/Resource/Writer.php
@@ -39,7 +39,7 @@ class Writer extends ResourceHanlder implements WriterInterface
      *
      * @return string
      */
-    protected function defaultMode()
+    protected function defaultMode(): string
     {
         return 'r+b';
     }
@@ -49,7 +49,7 @@ class Writer extends ResourceHanlder implements WriterInterface
      *
      * @return string|resource
      */
-    protected function defaultResource()
+    protected function defaultResource(): string
     {
         return 'php://stdout';
     }

--- a/src/Resource/Writer.php
+++ b/src/Resource/Writer.php
@@ -1,4 +1,6 @@
-<?php namespace Tarsana\Filesystem\Resource;
+<?php
+
+namespace Tarsana\Filesystem\Resource;
 
 use Tarsana\Filesystem\Interfaces\Resource\Writer as WriterInterface;
 use Tarsana\Filesystem\Exceptions\ResourceException;
@@ -6,8 +8,8 @@ use Tarsana\Filesystem\Exceptions\ResourceException;
 /**
  * Writes content to a resource.
  */
-class Writer extends ResourceHanlder implements WriterInterface {
-
+class Writer extends ResourceHanlder implements WriterInterface
+{
     /**
      * Writes content.
      *
@@ -15,8 +17,9 @@ class Writer extends ResourceHanlder implements WriterInterface {
      */
     public function write($content)
     {
-        if(false === fwrite($this->resource, $content))
+        if (false === fwrite($this->resource, $content)) {
             throw new ResourceException("Unable to write content to resource");
+        }
         return $this;
     }
 
@@ -61,5 +64,4 @@ class Writer extends ResourceHanlder implements WriterInterface {
     {
         return $this->isWritable($resource);
     }
-
 }

--- a/tests/Filesystem/Adapters/MemoryTest.php
+++ b/tests/Filesystem/Adapters/MemoryTest.php
@@ -1,12 +1,12 @@
 <?php
-use Tarsana\Filesystem\Filesystem;
+
 use Tarsana\Filesystem\Adapters\Memory;
 
-class MemoryTest extends PHPUnit\Framework\TestCase {
-
+class MemoryTest extends PHPUnit\Framework\TestCase
+{
     protected $m;
 
-    public function setUp()
+    public function setUp(): void
     {
         /**
          * foo/
@@ -18,7 +18,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase {
          * lorem/
          *   ipsum/
          */
-        $m = new Memory;
+        $m = new Memory();
         $m->mkdir('foo/bar/baz', 0755, true);
         $m->mkdir('lorem/ipsum', 0755, true);
         $m->filePutContents('foo/todo.txt', 'Write Awesome Code');

--- a/tests/Filesystem/Adapters/MemoryTest.php
+++ b/tests/Filesystem/Adapters/MemoryTest.php
@@ -27,14 +27,14 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->m = $m;
     }
 
-    public function test_realpath()
+    public function test_realpath(): void
     {
         $this->assertEquals(getcwd() . '/foo', $this->m->realpath('./foo'));
         $this->assertEquals(getcwd() . '/foo', $this->m->realpath('./foo/bar/../.'));
         $this->assertEquals(getcwd() . '/foo', $this->m->realpath('foo/./bar/..'));
     }
 
-    public function test_glob()
+    public function test_glob(): void
     {
 
         $this->assertEquals([], $this->m->glob('aa/*'));
@@ -42,40 +42,40 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertEquals([getcwd() . '/foo', getcwd() . '/lorem'], $this->m->glob('*'));
     }
 
-    public function test_isFile()
+    public function test_isFile(): void
     {
         $this->assertTrue($this->m->isFile('foo/todo.txt'));
         $this->assertFalse($this->m->isFile('foo/bar'));
         $this->assertFalse($this->m->isFile('foo/missing'));
     }
 
-    public function test_isDir()
+    public function test_isDir(): void
     {
         $this->assertTrue($this->m->isDir('foo/bar'));
         $this->assertFalse($this->m->isDir('foo/todo.txt'));
         $this->assertFalse($this->m->isDir('foo/missing'));
     }
 
-    public function test_fileExists()
+    public function test_fileExists(): void
     {
         $this->assertTrue($this->m->fileExists('foo/bar'));
         $this->assertTrue($this->m->fileExists('foo/todo.txt'));
         $this->assertFalse($this->m->fileExists('foo/missing'));
     }
 
-    public function test_md5File()
+    public function test_md5File(): void
     {
         $this->assertEquals(md5('Write Awesome Code'), $this->m->md5File('foo/todo.txt'));
         $this->assertFalse($this->m->md5File('foo/missing.txt'));
     }
 
-    public function test_fileGetContents()
+    public function test_fileGetContents(): void
     {
         $this->assertEquals('Write Awesome Code', $this->m->fileGetContents('foo/todo.txt'));
         $this->assertFalse($this->m->fileGetContents('foo/missing.txt'));
     }
 
-    public function test_filePutContents()
+    public function test_filePutContents(): void
     {
         $this->m->filePutContents('foo/todo.txt', 'Get Enough Sleep');
         $this->m->filePutContents('foo/missing.txt', 'Hello');
@@ -85,7 +85,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('Hello World', $this->m->fileGetContents('foo/missing.txt'));
     }
 
-    public function test_isReadable()
+    public function test_isReadable(): void
     {
         $this->m->chmod('foo/todo.txt', 0220);
         $this->m->chmod('foo/bar', 0220);
@@ -97,7 +97,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->m->isReadable('foo/bar'));
     }
 
-    public function test_isWritable()
+    public function test_isWritable(): void
     {
         $this->m->chmod('foo/todo.txt', 0555);
         $this->m->chmod('foo/bar', 0555);
@@ -109,7 +109,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->m->isWritable('foo/bar'));
     }
 
-    public function test_isExecutable()
+    public function test_isExecutable(): void
     {
         $this->m->chmod('foo/todo.txt', 0666);
         $this->m->chmod('foo/bar', 0666);
@@ -121,14 +121,14 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->m->isExecutable('foo/bar'));
     }
 
-    public function test_unlink()
+    public function test_unlink(): void
     {
         $this->assertTrue($this->m->fileExists('foo/todo.txt'));
         $this->m->unlink('foo/todo.txt');
         $this->assertFalse($this->m->fileExists('foo/todo.txt'));
     }
 
-    public function test_rmdir()
+    public function test_rmdir(): void
     {
         $this->assertTrue($this->m->fileExists('foo/bar/baz'));
         $this->assertTrue($this->m->rmdir('foo/bar/baz'));
@@ -138,7 +138,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->m->fileExists('foo/bar'));
     }
 
-    public function test_rename()
+    public function test_rename(): void
     {
         $this->assertTrue($this->m->rename('foo/todo.txt', 'foo/tasks.txt'));
         $this->assertFalse($this->m->fileExists('foo/todo.txt'));
@@ -156,7 +156,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->m->fileExists('lorem/new/aww.jpg'));
     }
 
-    public function test_fileperms_chmod()
+    public function test_fileperms_chmod(): void
     {
         $this->m->chmod('foo/todo.txt', 0666);
         $this->assertEquals(0666, $this->m->fileperms('foo/todo.txt'));
@@ -166,7 +166,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertFalse($this->m->fileperms('foo/missing.txt'));
     }
 
-    public function test_extension()
+    public function test_extension(): void
     {
         $this->assertEquals('jpg', $this->m->extension('foo/bar/aww.jpg'));
         $this->assertEquals('txt', $this->m->extension('foo/todo.txt'));
@@ -174,7 +174,7 @@ class MemoryTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('', $this->m->extension('foo/bar'));
     }
 
-    public function test_basename()
+    public function test_basename(): void
     {
         $this->assertEquals('aww.jpg', $this->m->basename('foo/bar/aww.jpg'));
         $this->assertEquals('todo.txt', $this->m->basename('foo/todo.txt'));

--- a/tests/Filesystem/CollectionTest.php
+++ b/tests/Filesystem/CollectionTest.php
@@ -24,7 +24,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         ]);
     }
 
-    public function test_adding_and_counting_elements()
+    public function test_adding_and_counting_elements(): void
     {
         $this->assertEquals(6, $this->collection->count());
 
@@ -36,20 +36,20 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(7, $this->collection->count());
     }
 
-    public function test_contains()
+    public function test_contains(): void
     {
         $this->assertTrue($this->collection->contains($this->tempPath . 'file1.txt'));
         $this->assertFalse($this->collection->contains($this->tempPath . 'file.txt'));
     }
 
-    public function test_gets_file_or_directory_by_path()
+    public function test_gets_file_or_directory_by_path(): void
     {
         $file = $this->collection->get($this->tempPath . 'file1.txt');
         $this->assertTrue($file instanceof File);
         $this->assertEquals('file1.txt', $file->name());
     }
 
-    public function test_updates_paths_automatically()
+    public function test_updates_paths_automatically(): void
     {
         $file = $this->collection->get($this->tempPath . 'file1.txt');
         $this->assertFalse($this->collection->contains($this->tempPath . 'other.txt'));
@@ -57,7 +57,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->collection->contains($this->tempPath . 'other.txt'));
     }
 
-    public function test_gets_all()
+    public function test_gets_all(): void
     {
         $array = $this->collection->asArray();
 
@@ -65,7 +65,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(6, count($array));
     }
 
-    public function test_gets_files()
+    public function test_gets_files(): void
     {
         $files = $this->collection->files();
 
@@ -73,7 +73,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(3, $files->count());
     }
 
-    public function test_gets_directories()
+    public function test_gets_directories(): void
     {
         $dirs = $this->collection->dirs();
 
@@ -81,7 +81,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(3, $dirs->count());
     }
 
-    public function test_gets_first_element()
+    public function test_gets_first_element(): void
     {
         $this->assertEquals(
             $this->tempPath . 'file1.txt',
@@ -89,7 +89,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_gets_last_element()
+    public function test_gets_last_element(): void
     {
         $this->assertEquals(
             $this->tempPath . 'dir1/file11.txt',
@@ -97,7 +97,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_gets_array_of_names()
+    public function test_gets_array_of_names(): void
     {
         $this->assertEquals(
             ['file1.txt', 'file2.txt', 'dir1', 'dir2', 'dir11', 'file11.txt'],
@@ -105,7 +105,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_gets_array_of_paths()
+    public function test_gets_array_of_paths(): void
     {
         $this->assertEquals(
             [
@@ -120,7 +120,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_removes_element_by_path()
+    public function test_removes_element_by_path(): void
     {
         $this->assertTrue($this->collection->contains($this->tempPath . 'dir1'));
 

--- a/tests/Filesystem/CollectionTest.php
+++ b/tests/Filesystem/CollectionTest.php
@@ -5,23 +5,22 @@ use Tarsana\Filesystem\Collection;
 use Tarsana\Filesystem\Directory;
 use Tarsana\Filesystem\File;
 
-
-class CollectionTest extends PHPUnit\Framework\TestCase {
-
+class CollectionTest extends PHPUnit\Framework\TestCase
+{
     protected $collection;
 
     protected $tempPath;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->tempPath = DEMO_DIR.'/temp/';
+        $this->tempPath = DEMO_DIR . '/temp/';
         $this->collection = new Collection([
-            new File($this->tempPath.'file1.txt'),
-            new File($this->tempPath.'file2.txt'),
-            new Directory($this->tempPath.'dir1'),
-            new Directory($this->tempPath.'dir2'),
-            new Directory($this->tempPath.'dir1/dir11'),
-            new File($this->tempPath.'dir1/file11.txt')
+            new File($this->tempPath . 'file1.txt'),
+            new File($this->tempPath . 'file2.txt'),
+            new Directory($this->tempPath . 'dir1'),
+            new Directory($this->tempPath . 'dir2'),
+            new Directory($this->tempPath . 'dir1/dir11'),
+            new File($this->tempPath . 'dir1/file11.txt')
         ]);
     }
 
@@ -29,33 +28,33 @@ class CollectionTest extends PHPUnit\Framework\TestCase {
     {
         $this->assertEquals(6, $this->collection->count());
 
-        $this->collection->add(new File($this->tempPath.'file3.txt'));
+        $this->collection->add(new File($this->tempPath . 'file3.txt'));
         $this->assertEquals(7, $this->collection->count());
 
         // Does not add the same file twice
-        $this->collection->add(new File($this->tempPath.'file1.txt'));
+        $this->collection->add(new File($this->tempPath . 'file1.txt'));
         $this->assertEquals(7, $this->collection->count());
     }
 
     public function test_contains()
     {
-        $this->assertTrue($this->collection->contains($this->tempPath.'file1.txt'));
-        $this->assertFalse($this->collection->contains($this->tempPath.'file.txt'));
+        $this->assertTrue($this->collection->contains($this->tempPath . 'file1.txt'));
+        $this->assertFalse($this->collection->contains($this->tempPath . 'file.txt'));
     }
 
     public function test_gets_file_or_directory_by_path()
     {
-        $file = $this->collection->get($this->tempPath.'file1.txt');
+        $file = $this->collection->get($this->tempPath . 'file1.txt');
         $this->assertTrue($file instanceof File);
         $this->assertEquals('file1.txt', $file->name());
     }
 
     public function test_updates_paths_automatically()
     {
-        $file = $this->collection->get($this->tempPath.'file1.txt');
-        $this->assertFalse($this->collection->contains($this->tempPath.'other.txt'));
+        $file = $this->collection->get($this->tempPath . 'file1.txt');
+        $this->assertFalse($this->collection->contains($this->tempPath . 'other.txt'));
         $file->name('other.txt', true);
-        $this->assertTrue($this->collection->contains($this->tempPath.'other.txt'));
+        $this->assertTrue($this->collection->contains($this->tempPath . 'other.txt'));
     }
 
     public function test_gets_all()
@@ -85,7 +84,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase {
     public function test_gets_first_element()
     {
         $this->assertEquals(
-            $this->tempPath.'file1.txt',
+            $this->tempPath . 'file1.txt',
             $this->collection->first()->path()
         );
     }
@@ -93,7 +92,7 @@ class CollectionTest extends PHPUnit\Framework\TestCase {
     public function test_gets_last_element()
     {
         $this->assertEquals(
-            $this->tempPath.'dir1/file11.txt',
+            $this->tempPath . 'dir1/file11.txt',
             $this->collection->last()->path()
         );
     }
@@ -110,12 +109,12 @@ class CollectionTest extends PHPUnit\Framework\TestCase {
     {
         $this->assertEquals(
             [
-                $this->tempPath.'file1.txt',
-                $this->tempPath.'file2.txt',
-                $this->tempPath.'dir1',
-                $this->tempPath.'dir2',
-                $this->tempPath.'dir1/dir11',
-                $this->tempPath.'dir1/file11.txt'
+                $this->tempPath . 'file1.txt',
+                $this->tempPath . 'file2.txt',
+                $this->tempPath . 'dir1',
+                $this->tempPath . 'dir2',
+                $this->tempPath . 'dir1/dir11',
+                $this->tempPath . 'dir1/file11.txt'
             ],
             $this->collection->paths()
         );
@@ -123,16 +122,16 @@ class CollectionTest extends PHPUnit\Framework\TestCase {
 
     public function test_removes_element_by_path()
     {
-        $this->assertTrue($this->collection->contains($this->tempPath.'dir1'));
+        $this->assertTrue($this->collection->contains($this->tempPath . 'dir1'));
 
-        $this->collection->remove($this->tempPath.'dir1');
+        $this->collection->remove($this->tempPath . 'dir1');
 
         $this->assertEquals(5, $this->collection->count());
-        $this->assertFalse($this->collection->contains($this->tempPath.'dir1'));
+        $this->assertFalse($this->collection->contains($this->tempPath . 'dir1'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        remove(DEMO_DIR.'/temp');
+        remove(DEMO_DIR . '/temp');
     }
 }

--- a/tests/Filesystem/DirectoryTest.php
+++ b/tests/Filesystem/DirectoryTest.php
@@ -4,35 +4,32 @@ use Tarsana\Filesystem\Filesystem;
 use Tarsana\Filesystem\Adapters\Local;
 use Tarsana\Filesystem\Directory;
 
-
-class DirectoryTest extends PHPUnit\Framework\TestCase {
-
+class DirectoryTest extends PHPUnit\Framework\TestCase
+{
     protected $dirPath;
 
     protected $dir;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->dirPath = DEMO_DIR.'/folder1';
+        $this->dirPath = DEMO_DIR . '/folder1';
         $this->dir = new Directory($this->dirPath);
     }
 
     public function test_creates_directory_if_missing()
     {
-        $this->assertFalse(is_dir(DEMO_DIR.'/temp'));
+        $this->assertFalse(is_dir(DEMO_DIR . '/temp'));
 
-        $dir = new Directory(DEMO_DIR.'/temp');
-        $this->assertTrue(is_dir(DEMO_DIR.'/temp'));
+        $dir = new Directory(DEMO_DIR . '/temp');
+        $this->assertTrue(is_dir(DEMO_DIR . '/temp'));
 
-        rmdir(DEMO_DIR.'/temp');
+        rmdir(DEMO_DIR . '/temp');
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\FilesystemException
-     */
     public function test_throws_exception_when_cannot_create_the_directory()
     {
-        $dir = new Directory(DEMO_DIR.'/files.txt');
+        $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
+        $dir = new Directory(DEMO_DIR . '/files.txt');
     }
 
     public function test_gets_filesystem_instance()
@@ -44,10 +41,10 @@ class DirectoryTest extends PHPUnit\Framework\TestCase {
     {
         $this->assertTrue($this->dir->exists());
 
-        $otherDir = new Directory(DEMO_DIR.'/temp');
+        $otherDir = new Directory(DEMO_DIR . '/temp');
         $this->assertTrue($otherDir->exists());
 
-        rmdir(DEMO_DIR.'/temp');
+        rmdir(DEMO_DIR . '/temp');
         $this->assertFalse($otherDir->exists());
     }
 
@@ -55,9 +52,9 @@ class DirectoryTest extends PHPUnit\Framework\TestCase {
     {
         $this->assertEquals($this->dirPath, $this->dir->path());
 
-        $this->dir->path(DEMO_DIR.'/folder2/folder1', true);
-        $this->assertEquals(DEMO_DIR.'/folder2/folder1', $this->dir->path());
-        $this->assertTrue(is_dir(DEMO_DIR.'/folder2/folder1'));
+        $this->dir->path(DEMO_DIR . '/folder2/folder1', true);
+        $this->assertEquals(DEMO_DIR . '/folder2/folder1', $this->dir->path());
+        $this->assertTrue(is_dir(DEMO_DIR . '/folder2/folder1'));
 
         $this->dir->path($this->dirPath);
         $this->assertEquals($this->dirPath, $this->dir->path());
@@ -70,8 +67,8 @@ class DirectoryTest extends PHPUnit\Framework\TestCase {
 
         $this->dir->name('new-folder');
         $this->assertEquals('new-folder', $this->dir->name());
-        $this->assertEquals(DEMO_DIR.'/new-folder', $this->dir->path());
-        $this->assertTrue(is_dir(DEMO_DIR.'/new-folder'));
+        $this->assertEquals(DEMO_DIR . '/new-folder', $this->dir->path());
+        $this->assertTrue(is_dir(DEMO_DIR . '/new-folder'));
 
         $this->dir->name('folder1');
         $this->assertEquals('folder1', $this->dir->name());
@@ -91,11 +88,11 @@ class DirectoryTest extends PHPUnit\Framework\TestCase {
 
     public function test_copy_as()
     {
-        $copy = $this->dir->copyAs(DEMO_DIR.'/copies/folder1');
+        $copy = $this->dir->copyAs(DEMO_DIR . '/copies/folder1');
 
-        $this->assertTrue(is_dir(DEMO_DIR.'/copies/folder1'));
+        $this->assertTrue(is_dir(DEMO_DIR . '/copies/folder1'));
         $this->assertTrue($copy instanceof Directory);
-        $this->assertEquals(DEMO_DIR.'/copies/folder1', $copy->path());
+        $this->assertEquals(DEMO_DIR . '/copies/folder1', $copy->path());
 
         $this->assertEquals(1, $copy->fs()->dirs()->count());
         $this->assertEquals(2, $copy->fs()->files()->count());
@@ -105,19 +102,19 @@ class DirectoryTest extends PHPUnit\Framework\TestCase {
 
     public function test_remove()
     {
-        $dir = new Directory(DEMO_DIR.'/temp');
+        $dir = new Directory(DEMO_DIR . '/temp');
         $this->assertTrue(
-            file_exists(DEMO_DIR.'/temp')
-            && is_dir(DEMO_DIR.'/temp')
+            file_exists(DEMO_DIR . '/temp')
+            && is_dir(DEMO_DIR . '/temp')
         );
 
         $dir->remove();
-        $this->assertFalse(file_exists(DEMO_DIR.'/temp'));
+        $this->assertFalse(file_exists(DEMO_DIR . '/temp'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        remove(DEMO_DIR.'/temp');
-        remove(DEMO_DIR.'/copies');
+        remove(DEMO_DIR . '/temp');
+        remove(DEMO_DIR . '/copies');
     }
 }

--- a/tests/Filesystem/DirectoryTest.php
+++ b/tests/Filesystem/DirectoryTest.php
@@ -16,7 +16,7 @@ class DirectoryTest extends PHPUnit\Framework\TestCase
         $this->dir = new Directory($this->dirPath);
     }
 
-    public function test_creates_directory_if_missing()
+    public function test_creates_directory_if_missing(): void
     {
         $this->assertFalse(is_dir(DEMO_DIR . '/temp'));
 
@@ -26,18 +26,18 @@ class DirectoryTest extends PHPUnit\Framework\TestCase
         rmdir(DEMO_DIR . '/temp');
     }
 
-    public function test_throws_exception_when_cannot_create_the_directory()
+    public function test_throws_exception_when_cannot_create_the_directory(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $dir = new Directory(DEMO_DIR . '/files.txt');
     }
 
-    public function test_gets_filesystem_instance()
+    public function test_gets_filesystem_instance(): void
     {
         $this->assertTrue($this->dir->fs() instanceof Filesystem);
     }
 
-    public function test_exists()
+    public function test_exists(): void
     {
         $this->assertTrue($this->dir->exists());
 
@@ -48,7 +48,7 @@ class DirectoryTest extends PHPUnit\Framework\TestCase
         $this->assertFalse($otherDir->exists());
     }
 
-    public function test_gets_and_sets_absolute_path()
+    public function test_gets_and_sets_absolute_path(): void
     {
         $this->assertEquals($this->dirPath, $this->dir->path());
 
@@ -61,7 +61,7 @@ class DirectoryTest extends PHPUnit\Framework\TestCase
         $this->assertTrue(is_dir($this->dirPath));
     }
 
-    public function test_gets_and_sets_name()
+    public function test_gets_and_sets_name(): void
     {
         $this->assertEquals('folder1', $this->dir->name());
 
@@ -86,7 +86,7 @@ class DirectoryTest extends PHPUnit\Framework\TestCase
     //     $this->assertEquals('0777', $this->dir->perms());
     // }
 
-    public function test_copy_as()
+    public function test_copy_as(): void
     {
         $copy = $this->dir->copyAs(DEMO_DIR . '/copies/folder1');
 
@@ -100,7 +100,7 @@ class DirectoryTest extends PHPUnit\Framework\TestCase
         $copy->remove();
     }
 
-    public function test_remove()
+    public function test_remove(): void
     {
         $dir = new Directory(DEMO_DIR . '/temp');
         $this->assertTrue(

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -17,7 +17,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->file = new File($this->filePath);
     }
 
-    public function test_creates_file_if_missing()
+    public function test_creates_file_if_missing(): void
     {
         unlink($this->filePath);
         $this->assertFalse(is_file($this->filePath));
@@ -26,18 +26,18 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertTrue(is_file($this->filePath));
     }
 
-    public function test_throws_exception_when_directory_exists_with_same_path()
+    public function test_throws_exception_when_directory_exists_with_same_path(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $file = new File(DEMO_DIR . '/folder1');
     }
 
-    public function test_gets_filesystem_instance()
+    public function test_gets_filesystem_instance(): void
     {
         $this->assertTrue($this->file->fs() instanceof Filesystem);
     }
 
-    public function test_exists()
+    public function test_exists(): void
     {
         $this->assertTrue($this->file->exists());
 
@@ -45,7 +45,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertFalse($this->file->exists());
     }
 
-    public function test_gets_and_sets_absolute_path()
+    public function test_gets_and_sets_absolute_path(): void
     {
         $this->assertEquals($this->filePath, $this->file->path());
 
@@ -58,7 +58,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertTrue(is_file($this->filePath));
     }
 
-    public function test_throws_exception_when_already_exists_path()
+    public function test_throws_exception_when_already_exists_path(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $path = DEMO_DIR . '/temp-2.txt';
@@ -66,7 +66,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->file->path($path);
     }
 
-    public function test_gets_and_sets_name()
+    public function test_gets_and_sets_name(): void
     {
         $this->assertEquals('temp.txt', $this->file->name());
 
@@ -81,13 +81,13 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertTrue(is_file($this->filePath));
     }
 
-    public function test_throws_exception_when_invalid_name()
+    public function test_throws_exception_when_invalid_name(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $this->file->name('');
     }
 
-    public function test_gets_and_sets_permissions()
+    public function test_gets_and_sets_permissions(): void
     {
         chmod($this->filePath, 0755);
         $this->assertEquals('0755', $this->file->perms());
@@ -96,7 +96,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('0777', $this->file->perms());
     }
 
-    public function test_is_writable()
+    public function test_is_writable(): void
     {
         chmod($this->filePath, 0444);
         $this->assertFalse($this->file->isWritable());
@@ -105,7 +105,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertTrue($this->file->isWritable());
     }
 
-    public function test_is_executable()
+    public function test_is_executable(): void
     {
         chmod($this->filePath, 0444);
         $this->assertFalse($this->file->isExecutable());
@@ -116,7 +116,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         chmod($this->filePath, 0777);
     }
 
-    public function test_sets_and_gets_extension()
+    public function test_sets_and_gets_extension(): void
     {
         $this->assertEquals('txt', $this->file->extension());
 
@@ -132,7 +132,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->file->name('temp.txt');
     }
 
-    public function test_gets_and_sets_content()
+    public function test_gets_and_sets_content(): void
     {
         file_put_contents($this->filePath, 'The obligatory Hello World !');
         $this->assertEquals('The obligatory Hello World !', $this->file->content());
@@ -141,7 +141,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('A new content', file_get_contents($this->filePath));
     }
 
-    public function test_append()
+    public function test_append(): void
     {
         file_put_contents($this->filePath, 'The obligatory ');
         $this->file->append('Hello World !');
@@ -149,7 +149,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('The obligatory Hello World !', file_get_contents($this->filePath));
     }
 
-    public function test_copy_as()
+    public function test_copy_as(): void
     {
         file_put_contents($this->filePath, 'Some content');
         $copy = $this->file->copyAs(DEMO_DIR . '/copies/new-temp.txt');
@@ -162,13 +162,13 @@ class FileTest extends PHPUnit\Framework\TestCase
         new Directory(DEMO_DIR . '/copies')->remove();
     }
 
-    public function test_gets_hash()
+    public function test_gets_hash(): void
     {
         file_put_contents($this->filePath, 'The obligatory Hello World !');
         $this->assertEquals(md5_file($this->filePath), $this->file->hash());
     }
 
-    public function test_remove()
+    public function test_remove(): void
     {
         $file = new File($this->filePath);
         $this->assertTrue(

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -159,7 +159,7 @@ class FileTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(DEMO_DIR . '/copies/new-temp.txt', $copy->path());
         $this->assertEquals('Some content', file_get_contents(DEMO_DIR . '/copies/new-temp.txt'));
 
-        (new Directory(DEMO_DIR . '/copies'))->remove();
+        new Directory(DEMO_DIR . '/copies')->remove();
     }
 
     public function test_gets_hash()

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -5,16 +5,15 @@ use Tarsana\Filesystem\Adapters\Local;
 use Tarsana\Filesystem\Directory;
 use Tarsana\Filesystem\File;
 
-
-class FileTest extends PHPUnit\Framework\TestCase {
-
+class FileTest extends PHPUnit\Framework\TestCase
+{
     protected $filePath;
 
     protected $file;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->filePath = DEMO_DIR.'/temp.txt';
+        $this->filePath = DEMO_DIR . '/temp.txt';
         $this->file = new File($this->filePath);
     }
 
@@ -27,12 +26,10 @@ class FileTest extends PHPUnit\Framework\TestCase {
         $this->assertTrue(is_file($this->filePath));
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\FilesystemException
-     */
     public function test_throws_exception_when_directory_exists_with_same_path()
     {
-        $file = new File(DEMO_DIR.'/folder1');
+        $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
+        $file = new File(DEMO_DIR . '/folder1');
     }
 
     public function test_gets_filesystem_instance()
@@ -52,21 +49,19 @@ class FileTest extends PHPUnit\Framework\TestCase {
     {
         $this->assertEquals($this->filePath, $this->file->path());
 
-        $this->file->path(DEMO_DIR.'/folder2/temp.txt', true);
-        $this->assertEquals(DEMO_DIR.'/folder2/temp.txt', $this->file->path());
-        $this->assertTrue(is_file(DEMO_DIR.'/folder2/temp.txt'));
+        $this->file->path(DEMO_DIR . '/folder2/temp.txt', true);
+        $this->assertEquals(DEMO_DIR . '/folder2/temp.txt', $this->file->path());
+        $this->assertTrue(is_file(DEMO_DIR . '/folder2/temp.txt'));
 
         $this->file->path($this->filePath);
         $this->assertEquals($this->filePath, $this->file->path());
         $this->assertTrue(is_file($this->filePath));
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\FilesystemException
-     */
     public function test_throws_exception_when_already_exists_path()
     {
-        $path = DEMO_DIR.'/temp-2.txt';
+        $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
+        $path = DEMO_DIR . '/temp-2.txt';
         file_put_contents($path, '');
         $this->file->path($path);
     }
@@ -77,8 +72,8 @@ class FileTest extends PHPUnit\Framework\TestCase {
 
         $this->file->name('new-temp.txt');
         $this->assertEquals('new-temp.txt', $this->file->name());
-        $this->assertEquals(DEMO_DIR.'/new-temp.txt', $this->file->path());
-        $this->assertTrue(is_file(DEMO_DIR.'/new-temp.txt'));
+        $this->assertEquals(DEMO_DIR . '/new-temp.txt', $this->file->path());
+        $this->assertTrue(is_file(DEMO_DIR . '/new-temp.txt'));
 
         $this->file->name('temp.txt');
         $this->assertEquals('temp.txt', $this->file->name());
@@ -86,11 +81,9 @@ class FileTest extends PHPUnit\Framework\TestCase {
         $this->assertTrue(is_file($this->filePath));
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\FilesystemException
-     */
     public function test_throws_exception_when_invalid_name()
     {
+        $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $this->file->name('');
     }
 
@@ -159,14 +152,14 @@ class FileTest extends PHPUnit\Framework\TestCase {
     public function test_copy_as()
     {
         file_put_contents($this->filePath, 'Some content');
-        $copy = $this->file->copyAs(DEMO_DIR.'/copies/new-temp.txt');
+        $copy = $this->file->copyAs(DEMO_DIR . '/copies/new-temp.txt');
 
-        $this->assertTrue(is_file(DEMO_DIR.'/copies/new-temp.txt'));
+        $this->assertTrue(is_file(DEMO_DIR . '/copies/new-temp.txt'));
         $this->assertTrue($copy instanceof File);
-        $this->assertEquals(DEMO_DIR.'/copies/new-temp.txt', $copy->path());
-        $this->assertEquals('Some content', file_get_contents(DEMO_DIR.'/copies/new-temp.txt'));
+        $this->assertEquals(DEMO_DIR . '/copies/new-temp.txt', $copy->path());
+        $this->assertEquals('Some content', file_get_contents(DEMO_DIR . '/copies/new-temp.txt'));
 
-        (new Directory(DEMO_DIR.'/copies'))->remove();
+        (new Directory(DEMO_DIR . '/copies'))->remove();
     }
 
     public function test_gets_hash()
@@ -187,10 +180,9 @@ class FileTest extends PHPUnit\Framework\TestCase {
         $this->assertFalse(file_exists($this->filePath));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        remove(DEMO_DIR.'/temp.txt');
-        remove(DEMO_DIR.'/temp-2.txt');
+        remove(DEMO_DIR . '/temp.txt');
+        remove(DEMO_DIR . '/temp-2.txt');
     }
-
 }

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -37,18 +37,18 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         $this->fs = new Filesystem(DEMO_DIR);
     }
 
-    public function test_throws_exception_if_root_directory_not_found()
+    public function test_throws_exception_if_root_directory_not_found(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $fs = new Filesystem(DEMO_DIR . '/none-present-folder');
     }
 
-    public function test_gets_root_path()
+    public function test_gets_root_path(): void
     {
         $this->assertEquals(DEMO_DIR . '/', $this->fs->path());
     }
 
-    public function test_gets_the_type_of_path_or_pattern()
+    public function test_gets_the_type_of_path_or_pattern(): void
     {
         $this->assertEquals('file', $this->fs->whatIs('folder1/some-doc.txt'));
         $this->assertEquals('file', $this->fs->whatIs('folder1/*-doc.txt'));
@@ -59,20 +59,20 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         $this->assertEquals('collection', $this->fs->whatIs('folder*/*.mp3'));
     }
 
-    public function test_checks_if_file_exists()
+    public function test_checks_if_file_exists(): void
     {
         $this->assertTrue($this->fs->isFile('folder1/track.mp3'));
         $this->assertTrue($this->fs->isFile(DEMO_DIR . '/folder1/track.mp3'));
         $this->assertFalse($this->fs->isFile('folder1/track.txt'));
     }
 
-    public function test_checks_if_directory_exists()
+    public function test_checks_if_directory_exists(): void
     {
         $this->assertTrue($this->fs->isDir('folder4/folder42'));
         $this->assertFalse($this->fs->isDir('folder5'));
     }
 
-    public function test_checks_if_file_or_directory_exists()
+    public function test_checks_if_file_or_directory_exists(): void
     {
         $this->assertTrue($this->fs->isAny('folder1/track.mp3'));
         $this->assertFalse($this->fs->isAny('folder1/track.txt'));
@@ -80,7 +80,7 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         $this->assertFalse($this->fs->isAny('folder5'));
     }
 
-    public function test_checks_if_multiple_files_exist()
+    public function test_checks_if_multiple_files_exist(): void
     {
         $this->assertTrue($this->fs->areFiles([
             'folder1/track.mp3',
@@ -97,7 +97,7 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         ]));
     }
 
-    public function test_checks_if_multiple_directories_exist()
+    public function test_checks_if_multiple_directories_exist(): void
     {
         $this->assertTrue($this->fs->areDirs([
             'folder1',
@@ -113,7 +113,7 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         ]));
     }
 
-    public function test_checks_if_multiple_files_or_directories_exist()
+    public function test_checks_if_multiple_files_or_directories_exist(): void
     {
         $this->assertTrue($this->fs->areAny([
             'folder1',
@@ -129,7 +129,7 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         ]));
     }
 
-    public function test_gets_or_creates_files_by_name()
+    public function test_gets_or_creates_files_by_name(): void
     {
         $file = $this->fs->file('files.txt');
         $this->assertTrue($file instanceof File);
@@ -150,7 +150,7 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         $this->fs->dir('tmp')->remove();
     }
 
-    public function test_gets_or_creates_directories_by_name()
+    public function test_gets_or_creates_directories_by_name(): void
     {
         $dir = $this->fs->dir('folder1');
         $this->assertTrue($dir instanceof Directory);
@@ -170,19 +170,19 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(4, $dirs->count());
     }
 
-    public function test_throws_exception_if_file_not_found()
+    public function test_throws_exception_if_file_not_found(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $this->fs->file('none-present-file.txt');
     }
 
-    public function test_throws_exception_if_directory_not_found()
+    public function test_throws_exception_if_directory_not_found(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $this->fs->dir('none-present-folder');
     }
 
-    public function test_gets_files_or_directories_matching_pattern()
+    public function test_gets_files_or_directories_matching_pattern(): void
     {
         $found = $this->fs->find('f*');
         $this->assertTrue($found instanceof Collection);
@@ -191,7 +191,7 @@ class FilesystemTest extends PHPUnit\Framework\TestCase
         $this->assertEquals(4, $found->dirs()->count());
     }
 
-    public function test_removes_files_and_directories()
+    public function test_removes_files_and_directories(): void
     {
         $file = $this->fs->file('tmp/file.php', true);
         $this->assertTrue($this->fs->isFile('tmp/file.php'));

--- a/tests/FilesystemTest.php
+++ b/tests/FilesystemTest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Tarsana\Filesystem\Filesystem;
 use Tarsana\Filesystem\Adapters\Local;
 use Tarsana\Filesystem\Collection;
@@ -27,26 +28,24 @@ use Tarsana\Filesystem\File;
  * files.txt
  *
  */
-class LocalTest extends PHPUnit\Framework\TestCase {
-
+class FilesystemTest extends PHPUnit\Framework\TestCase
+{
     protected $fs;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fs = new Filesystem(DEMO_DIR);
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\FilesystemException
-     */
     public function test_throws_exception_if_root_directory_not_found()
     {
-        $fs = new Filesystem(DEMO_DIR.'/none-present-folder');
+        $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
+        $fs = new Filesystem(DEMO_DIR . '/none-present-folder');
     }
 
     public function test_gets_root_path()
     {
-        $this->assertEquals(DEMO_DIR.'/', $this->fs->path());
+        $this->assertEquals(DEMO_DIR . '/', $this->fs->path());
     }
 
     public function test_gets_the_type_of_path_or_pattern()
@@ -171,19 +170,15 @@ class LocalTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals(4, $dirs->count());
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\FilesystemException
-     */
     public function test_throws_exception_if_file_not_found()
     {
+        $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $this->fs->file('none-present-file.txt');
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\FilesystemException
-     */
     public function test_throws_exception_if_directory_not_found()
     {
+        $this->expectException(\Tarsana\Filesystem\Exceptions\FilesystemException::class);
         $this->fs->dir('none-present-folder');
     }
 
@@ -215,8 +210,8 @@ class LocalTest extends PHPUnit\Framework\TestCase {
         $this->assertFalse($this->fs->isDir('tmp/file.php'));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        remove(DEMO_DIR.'/tmp');
+        remove(DEMO_DIR . '/tmp');
     }
 }

--- a/tests/Resource/BufferTest.php
+++ b/tests/Resource/BufferTest.php
@@ -16,7 +16,7 @@ class BufferTest extends PHPUnit\Framework\TestCase
         $this->buffer = new Buffer($this->path);
     }
 
-    public function test_reads_content()
+    public function test_reads_content(): void
     {
         $this->assertEquals(
             "Hello World !",
@@ -24,14 +24,14 @@ class BufferTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_non_blocking()
+    public function test_non_blocking(): void
     {
         $in = new Buffer();
         $in->blocking(false);
         $this->assertEquals("", $in->read());
     }
 
-    public function test_close()
+    public function test_close(): void
     {
         $resource = fopen('php://memory', 'r+');
         $in = new Buffer($resource);
@@ -40,13 +40,13 @@ class BufferTest extends PHPUnit\Framework\TestCase
         $this->assertFalse(is_resource($resource));
     }
 
-    public function test_writes_content()
+    public function test_writes_content(): void
     {
         $this->buffer->write(" Hello");
         $this->assertEquals("Hello World ! Hello", file_get_contents($this->path));
     }
 
-    public function test_reads_and_writes_content()
+    public function test_reads_and_writes_content(): void
     {
         $this->assertEquals("Hello ", $this->buffer->read(6));
         $this->buffer->write(' Yo');
@@ -73,7 +73,7 @@ class BufferTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_throws_exception_if_empty_ending_word_given()
+    public function test_throws_exception_if_empty_ending_word_given(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
         $this->buffer->readUntil('');

--- a/tests/Resource/BufferTest.php
+++ b/tests/Resource/BufferTest.php
@@ -3,15 +3,15 @@
 use Tarsana\Filesystem\Adapters\Local;
 use Tarsana\Filesystem\Resource\Buffer;
 
-class BufferTest extends PHPUnit\Framework\TestCase {
-
+class BufferTest extends PHPUnit\Framework\TestCase
+{
     protected $buffer;
 
     protected $path;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->path = DEMO_DIR.'/temp.txt';
+        $this->path = DEMO_DIR . '/temp.txt';
         file_put_contents($this->path, "Hello World !");
         $this->buffer = new Buffer($this->path);
     }
@@ -26,7 +26,7 @@ class BufferTest extends PHPUnit\Framework\TestCase {
 
     public function test_non_blocking()
     {
-        $in = new Buffer;
+        $in = new Buffer();
         $in->blocking(false);
         $this->assertEquals("", $in->read());
     }
@@ -73,17 +73,14 @@ class BufferTest extends PHPUnit\Framework\TestCase {
         );
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\ResourceException
-     */
     public function test_throws_exception_if_empty_ending_word_given()
     {
+        $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
         $this->buffer->readUntil('');
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        remove(DEMO_DIR.'/temp.txt');
+        remove(DEMO_DIR . '/temp.txt');
     }
-
 }

--- a/tests/Resource/ReaderTest.php
+++ b/tests/Resource/ReaderTest.php
@@ -3,23 +3,21 @@
 use Tarsana\Filesystem\Adapters\Local;
 use Tarsana\Filesystem\Resource\Reader;
 
-class ReaderTest extends PHPUnit\Framework\TestCase {
-
+class ReaderTest extends PHPUnit\Framework\TestCase
+{
     protected $reader;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $path = DEMO_DIR.'/temp.txt';
+        $path = DEMO_DIR . '/temp.txt';
         file_put_contents($path, "Hello World !" . PHP_EOL . "How are you ?");
         $this->reader = new Reader($path);
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\ResourceException
-     */
     public function test_fails_if_not_readable()
     {
-        $writer = new Reader(fopen(DEMO_DIR.'/temp.txt', 'w'));
+        $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
+        $writer = new Reader(fopen(DEMO_DIR . '/temp.txt', 'w'));
     }
 
     public function test_reads_whole_content()
@@ -62,11 +60,9 @@ class ReaderTest extends PHPUnit\Framework\TestCase {
         );
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\ResourceException
-     */
     public function test_throws_exception_if_empty_ending_word_given()
     {
+        $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
         $this->reader->readUntil('');
     }
 
@@ -90,7 +86,7 @@ class ReaderTest extends PHPUnit\Framework\TestCase {
 
     public function test_non_blocking()
     {
-        $in = new Reader;
+        $in = new Reader();
         $in->blocking(false);
         $this->assertEquals("", $in->read());
     }
@@ -104,8 +100,8 @@ class ReaderTest extends PHPUnit\Framework\TestCase {
         $this->assertFalse(is_resource($resource));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        remove(DEMO_DIR.'/temp.txt');
+        remove(DEMO_DIR . '/temp.txt');
     }
 }

--- a/tests/Resource/ReaderTest.php
+++ b/tests/Resource/ReaderTest.php
@@ -14,13 +14,13 @@ class ReaderTest extends PHPUnit\Framework\TestCase
         $this->reader = new Reader($path);
     }
 
-    public function test_fails_if_not_readable()
+    public function test_fails_if_not_readable(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
         $writer = new Reader(fopen(DEMO_DIR . '/temp.txt', 'w'));
     }
 
-    public function test_reads_whole_content()
+    public function test_reads_whole_content(): void
     {
         $this->assertEquals(
             "Hello World !" . PHP_EOL . "How are you ?",
@@ -28,7 +28,7 @@ class ReaderTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_reads_one_line()
+    public function test_reads_one_line(): void
     {
         $this->assertEquals(
             "Hello World !",
@@ -36,7 +36,7 @@ class ReaderTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_reads_until_a_character()
+    public function test_reads_until_a_character(): void
     {
         $this->assertEquals(
             "Hello World !" . PHP_EOL . "How are ",
@@ -44,7 +44,7 @@ class ReaderTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_reads_until_a_word()
+    public function test_reads_until_a_word(): void
     {
         $this->assertEquals(
             "Hello World !" . PHP_EOL . "How",
@@ -52,7 +52,7 @@ class ReaderTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_reads_all_if_ending_word_not_found()
+    public function test_reads_all_if_ending_word_not_found(): void
     {
         $this->assertEquals(
             "Hello World !" . PHP_EOL . "How are you ?",
@@ -60,13 +60,13 @@ class ReaderTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_throws_exception_if_empty_ending_word_given()
+    public function test_throws_exception_if_empty_ending_word_given(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
         $this->reader->readUntil('');
     }
 
-    public function test_reads_part_of_content()
+    public function test_reads_part_of_content(): void
     {
         $this->assertEquals(
             "Hello",
@@ -84,14 +84,14 @@ class ReaderTest extends PHPUnit\Framework\TestCase
         );
     }
 
-    public function test_non_blocking()
+    public function test_non_blocking(): void
     {
         $in = new Reader();
         $in->blocking(false);
         $this->assertEquals("", $in->read());
     }
 
-    public function test_close()
+    public function test_close(): void
     {
         $resource = fopen('php://memory', 'r');
         $in = new Reader($resource);

--- a/tests/Resource/WriterTest.php
+++ b/tests/Resource/WriterTest.php
@@ -3,30 +3,28 @@
 use Tarsana\Filesystem\Adapters\Local;
 use Tarsana\Filesystem\Resource\Writer;
 
-class WriterTest extends PHPUnit\Framework\TestCase {
-
+class WriterTest extends PHPUnit\Framework\TestCase
+{
     protected $writer;
 
     protected $path;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->path = DEMO_DIR.'/temp.txt';
+        $this->path = DEMO_DIR . '/temp.txt';
         file_put_contents($this->path, "");
         $this->writer = new Writer($this->path);
     }
 
-    /**
-     * @expectedException Tarsana\Filesystem\Exceptions\ResourceException
-     */
     public function test_fails_if_not_writable()
     {
+        $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
         $writer = new Writer(fopen('php://memory', 'r'));
     }
 
     public function test_constructor()
     {
-        $out = new Writer;
+        $out = new Writer();
         $this->assertTrue($out instanceof Writer);
     }
 
@@ -48,9 +46,8 @@ class WriterTest extends PHPUnit\Framework\TestCase {
         $this->assertEquals("Hello World" . PHP_EOL, file_get_contents($this->path));
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
-        remove(DEMO_DIR.'/temp.txt');
+        remove(DEMO_DIR . '/temp.txt');
     }
-
 }

--- a/tests/Resource/WriterTest.php
+++ b/tests/Resource/WriterTest.php
@@ -16,19 +16,19 @@ class WriterTest extends PHPUnit\Framework\TestCase
         $this->writer = new Writer($this->path);
     }
 
-    public function test_fails_if_not_writable()
+    public function test_fails_if_not_writable(): void
     {
         $this->expectException(\Tarsana\Filesystem\Exceptions\ResourceException::class);
         $writer = new Writer(fopen('php://memory', 'r'));
     }
 
-    public function test_constructor()
+    public function test_constructor(): void
     {
         $out = new Writer();
         $this->assertTrue($out instanceof Writer);
     }
 
-    public function test_close()
+    public function test_close(): void
     {
         $resource = fopen('php://memory', 'w');
         $out = new Writer($resource);
@@ -37,7 +37,7 @@ class WriterTest extends PHPUnit\Framework\TestCase
         $this->assertFalse(is_resource($resource));
     }
 
-    public function test_writes_content()
+    public function test_writes_content(): void
     {
         $this->writer->write("Hello");
         $this->assertEquals("Hello", file_get_contents($this->path));

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,13 +2,15 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-define('DEMO_DIR', __DIR__.'/demo');
+define('DEMO_DIR', __DIR__ . '/demo');
 
-function remove($path) {
-    if (is_file($path))
+function remove($path)
+{
+    if (is_file($path)) {
         return unlink($path);
+    }
     if (is_dir($path)) {
-        $path = rtrim($path, '/');
+        $path = rtrim((string) $path, '/');
         $files = glob($path . '/*', GLOB_MARK);
         foreach ($files as $file) {
             remove($file);


### PR DESCRIPTION
Migrate to PHP 8.3 using Rector, PHPCS and manual code changes.
After this job, all tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added path() and adapter() accessors to Filesystem; added writeLine() to Writer.

* **Bug Fixes / Improvements**
  * Improved type safety and stricter return contracts across adapters and resources.
  * Cleaner error/exception behavior for creation failures.

* **Infrastructure**
  * Bumped minimum PHP requirement to 8.4; CI and Docker updated for PHP 8.4.
  * Added tooling scripts for testing and code quality.

* **Chores**
  * Updated repository ignore rules to exclude root dotfiles.

* **Tests**
  * Modernized test suite signatures and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->